### PR TITLE
prompts and plugin installation process

### DIFF
--- a/libs/WPME/Extensions/Clever/Plugins.php
+++ b/libs/WPME/Extensions/Clever/Plugins.php
@@ -73,8 +73,7 @@ class Plugins
                 jQuery(function() {
                     // On install
                     jQuery(document).on('wp-plugin-install-success', function(event, data){
-                        if (data.slug.indexOf("wpmktgengine") !== -1) {
-                            // Get container
+                        // Get container
                             var url = ajaxurl.replace(/[^\/]*$/, '');
                             var append = jQuery('.wpme-plugin-notice.plugin-card-' + data.slug);
                             // Append activate message
@@ -87,7 +86,7 @@ class Plugins
                                     .attr('href', '')
                                     .removeClass('thickbox')
                                     .removeClass('open-plugin-details-modal');
-                        }
+                       
                         return;
                     });
                 });

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.6.0
 Tested up to: 5.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Stable tag: 4.0.15
+Stable tag: 4.0.16
 
 
 WPMktgEngine turns your WordPress site into a marketing engine for your business.  A comprehensive online marketing platform.

--- a/wpmktgengine.php
+++ b/wpmktgengine.php
@@ -5,7 +5,7 @@
     Author:  Genoo, LLC
     Author URI: http://www.genoo.com/
     Author Email: info@genoo.com
-    Version: 4.0.15
+    Version: 4.0.16
     License: GPLv2
     Text Domain: wpmktgengine
 */


### PR DESCRIPTION
1)Fixed issue - while activating the plugin its prompts popup instead of getting activated.
Removed index of data-slug condition because some of our plugins data-slug did not contain the word "wpmktgengine".