### PR TITLE
Fix PHP 8.2+ Deprecation Warnings and Dynamic Property Declarations

### DIFF
--- a/libs/WPME/Customizer/TemplateStorage.php
+++ b/libs/WPME/Customizer/TemplateStorage.php
@@ -337,6 +337,11 @@ class TemplateStorage
 
     public function removeSpecificStyleAttributes(&$form)
     {
+        // Handle null input to prevent PHP 8.1+ deprecation warnings
+        if ($form === null) {
+            $form = '';
+            return $form;
+        }
         // $form = preg_replace('%style="[^"]+"%i', '', $form, -1);
         $form = preg_replace('/background-color:[ ]{0,1}(#(?:[0-9a-f]{2}){2,4}|(#[0-9a-f]{3})|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))[;]{0,1}/m', '', $form);
         $form = preg_replace('/color:[ ]{0,1}(#(?:[0-9a-f]{2}){2,4}|(#[0-9a-f]{3})|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))[;]{0,1}/m', '', $form);
@@ -376,6 +381,10 @@ class TemplateStorage
      */
     public function __cleanUpForCustomizer($html, $blockElements = true)
     {
+        // Handle null input to prevent PHP 8.1+ deprecation warnings
+        if ($html === null) {
+            $html = '';
+        }
         $html = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $html);
         if($blockElements){
             $html = str_replace(

--- a/libs/WPME/Utils/FastImage.php
+++ b/libs/WPME/Utils/FastImage.php
@@ -32,7 +32,7 @@ namespace WPME\Utils;
 class FastImage
 {
     private $strpos = 0;
-    private $str;
+    private $str = '';
     private $type;
     private $handle;
 
@@ -53,7 +53,7 @@ class FastImage
             fclose($this->handle);
             $this->handle = null;
             $this->type = null;
-            $this->str = null;
+            $this->str = '';
         }
     }
     public function getSize()

--- a/libs/WPMKTENGINE/CTA.php
+++ b/libs/WPMKTENGINE/CTA.php
@@ -32,6 +32,8 @@ class CTA
     public $postObject;
     /** @var array post types */
     public $postTypes;
+    /** @var int|string|null CTA ID */
+    public $id = null;
     /** @var bool */
     public $has = false;
     /** @var bool */

--- a/libs/WPMKTENGINE/Frontend.php
+++ b/libs/WPMKTENGINE/Frontend.php
@@ -44,6 +44,8 @@ class Frontend
     var $api;
     /** @var Cache */
     var $cache;
+    /** @var bool Whether the current post has multiple CTAs */
+    var $hasMultipleCTAs = false;
 
     /**
      * Construct Frontend

--- a/libs/WPMKTENGINE/HtmlForm.php
+++ b/libs/WPMKTENGINE/HtmlForm.php
@@ -290,7 +290,8 @@ class HtmlForm
     public function getUniqueId()
     {
         static $counter = 1;
-        $data = preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $this->dom->saveHTML());
+        $html = $this->dom->saveHTML();
+        $data = preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $html !== false ? $html : '');
         $unique_id = '_' . $counter . '_' . sha1($data);
         $counter++;
         return $unique_id;
@@ -305,7 +306,8 @@ class HtmlForm
     public function __toString()
     {
         // Get data
-        $data = preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $this->dom->saveHTML());
+        $html = $this->dom->saveHTML();
+        $data = preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $html !== false ? $html : '');
         // Add uniqe form identificator
         if(isset($this->form_key) && !empty($this->form_key) && (isset($this->form_id) && (!empty($this->form_id)))){
             // Okay, we have a form key, lets get unique number

--- a/libs/WPMKTENGINE/HtmlForm.php
+++ b/libs/WPMKTENGINE/HtmlForm.php
@@ -28,17 +28,19 @@ class HtmlForm
     private $html;
     /** @var \DOMDocument */
     private $dom;
-    /** @var */
+    /** @var \DOMElement|null */
     private $form;
-    /** @var */
+    /** @var \DOMElement|null */
+    private $msg;
+    /** @var string|null */
     private $form_key;
-    /** @var  */
+    /** @var string|null */
     private $form_return = NULL;
-    /** @var */
+    /** @var string|null */
     private $form_id;
     /** @var string */
     private $unique;
-    /** @var string */
+    /** @var string|null */
     private $validator;
     /** @var int */
     static $count = 1;

--- a/libs/WPMKTENGINE/Table.php
+++ b/libs/WPMKTENGINE/Table.php
@@ -40,6 +40,16 @@ abstract class Table extends \WPMKTENGINE\Wordpress\TableLite
     var $screen;
     /** @var string */
     var $searchQuery;
+    /** @var string Screen ID */
+    var $screenId;
+    /** @var bool Screen options flag */
+    var $screenOptions;
+    /** @var int|bool User per page setting */
+    var $userPerpage;
+    /** @var int Items per page */
+    var $perPage;
+    /** @var array Found data for pagination */
+    var $found_data = array();
 
     /**
      * Constructor

--- a/libs/WPMKTENGINE/Utils/Strings.php
+++ b/libs/WPMKTENGINE/Utils/Strings.php
@@ -177,6 +177,10 @@ class Strings
 
 	public static function toAscii($s)
 	{
+		// Handle null input to avoid PHP 8.1+ deprecation warning
+		if ($s === null) {
+			return '';
+		}
 		$s = \preg_replace('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s);
 		$s = \strtr($s, '`\'"^~', "\x01\x02\x03\x04\x05");
 		if (defined('ICONV_IMPL') && function_exists('iconv')) {

--- a/libs/WPMKTENGINE/WidgetCTAVisible.php
+++ b/libs/WPMKTENGINE/WidgetCTAVisible.php
@@ -33,6 +33,11 @@ use WPMKTENGINE\Wordpress\Post;
 
 class WidgetCTAVisible extends \WPMKTENGINE\WidgetCTA
 {
+    /** @var array List of available CTAs */
+    var $ctas = array();
+    /** @var array Selected CTA IDs */
+    var $selected = array();
+
     /**
      * Constructor registers widget in WordPress
      */

--- a/libs/WPMKTENGINE/Wordpress/Metabox.php
+++ b/libs/WPMKTENGINE/Wordpress/Metabox.php
@@ -148,14 +148,16 @@ class Metabox
         // go through fields
         if(is_array($this->fields) && !empty($this->fields)){
             foreach($this->fields as $field){
-                $fieldId = isset($field['id']) ? $field['id'] : str_replace('-', '_', Strings::lower(Strings::webalize($field['label'])));
-                if(isset($field['type']) && (isset($field['label']))){
-                    $fieldRow = '<tr class="themeMetaboxRow" id="themeMetaboxRow'. $fieldId .'" >';
-                    $fieldValue = get_post_meta($post->ID, $fieldId, true);
-                    $fieldLabel = '<td class="genooLabel"><label for="' . $fieldId . '">' . $field['label'] . '</label></td><td>';
-                    $fieldOptions = isset($field['options']) ? $field['options'] : array();
-                    $fieldAtts = '';
+                // Skip fields without required type and label
+                if(!isset($field['type']) || !isset($field['label'])){
+                    continue;
                 }
+                $fieldId = isset($field['id']) ? $field['id'] : str_replace('-', '_', Strings::lower(Strings::webalize($field['label'])));
+                $fieldRow = '<tr class="themeMetaboxRow" id="themeMetaboxRow'. $fieldId .'" >';
+                $fieldValue = get_post_meta($post->ID, $fieldId, true);
+                $fieldLabel = '<td class="genooLabel"><label for="' . $fieldId . '">' . $field['label'] . '</label></td><td>';
+                $fieldOptions = isset($field['options']) ? $field['options'] : array();
+                $fieldAtts = '';
                 $fieldDesc = '';
                 if(isset($field['desc'])){
                     $fieldDesc = $field['desc'];

--- a/libs/WPMKTENGINE/Wordpress/Metabox.php
+++ b/libs/WPMKTENGINE/Wordpress/Metabox.php
@@ -119,6 +119,10 @@ class Metabox
         // Update the meta fields
         if(is_array($this->fields) && !empty($this->fields)){
             foreach($this->fields as $field){
+                // Skip fields without required label (needed to generate fieldId)
+                if(!isset($field['id']) && !isset($field['label'])){
+                    continue;
+                }
                 $fieldId = isset($field['id']) ? $field['id'] : str_replace('-', '_', Strings::lower(Strings::webalize($field['label'])));
                 if(!empty($_POST[$fieldId])){
                     if(in_array($fieldId, array('wpmktengine_data_header', 'wpmktengine_data_footer'))){

--- a/libs/WPMKTENGINE/Wordpress/MetaboxCTA.php
+++ b/libs/WPMKTENGINE/Wordpress/MetaboxCTA.php
@@ -238,15 +238,16 @@ class MetaboxCTA extends Metabox
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
         $r = array();
         if(isset($_POST[$this->id]) && is_array($_POST[$this->id])){
-            foreach($_POST[$this->id] as $key => $value){
-                $_POST[$this->id][$key] = sanitize_text_field($value);
-            }
+            // Process and sanitize the nested array structure
+            // $_POST[$this->id] structure: ['cta' => [...], 'sidebar' => [...], 'position' => [...]]
             foreach($_POST[$this->id] as $key => $value){
                 $current = $key;
                 if(is_array($value)){
                     foreach($value as $row => $field){
-                        if(!empty($field)){
-                            $r[$row][$current] = $field;
+                        // Sanitize each individual field value
+                        $sanitized_field = sanitize_text_field($field);
+                        if(!empty($sanitized_field)){
+                            $r[$row][$current] = $sanitized_field;
                         }
                     }
                 }

--- a/libs/WPMKTENGINE/Wordpress/TableLite.php
+++ b/libs/WPMKTENGINE/Wordpress/TableLite.php
@@ -87,6 +87,15 @@ class TableLite {
     private $_pagination;
 
     /**
+     * Cached column headers
+     *
+     * @since 3.1.0
+     * @var array
+     * @access protected
+     */
+    protected $_column_headers;
+
+    /**
      * The view switcher modes.
      *
      * @since 4.1.0


### PR DESCRIPTION
Summary
This PR addresses multiple PHP 8.2+ deprecation warnings and compatibility issues throughout the WPMktgEngine plugin, ensuring full compatibility with modern PHP versions.

Changes
Dynamic Property Declarations (PHP 8.2 Deprecation)
Added explicit property declarations to prevent "Creation of dynamic property" deprecation warnings:
libs/WPMKTENGINE/CTA.php - Added public $id = null;
libs/WPMKTENGINE/Frontend.php - Added public $hasMultipleCTAs = false;
libs/WPMKTENGINE/HtmlForm.php - Added private $msg = null;
libs/WPMKTENGINE/WidgetCTAVisible.php - Added $ctas and $selected properties
libs/WPMKTENGINE/Table.php - Added $screenId, $screenOptions, $userPerpage, $perPage, $found_data properties
libs/WPMKTENGINE/Wordpress/TableLite.php - Added $_column_headers property
libs/WPME/Utils/FastImage.php - Initialized $str property to empty string
Null Parameter Handling (PHP 8.1+ Deprecation)
Fixed deprecated null parameter passing to internal functions:
libs/WPMKTENGINE/Utils/Strings.php - Added null check in toAscii() to prevent preg_replace() null subject warning
libs/WPME/Utils/FastImage.php - Fixed strlen(null) deprecation by properly initializing $str
libs/WPME/Customizer/TemplateStorage.php - Added null checks in removeSpecificStyleAttributes() and __cleanUpForCustomizer()
libs/WPMKTENGINE/HtmlForm.php - Added false check for saveHTML() return value before preg_replace()
Array Offset on Null Warnings
libs/WPMKTENGINE/Wordpress/Metabox.php - Added isset checks for $field['type'] and $field['label'] in both render() and save() methods

Bug Fix: Dynamic CTA Save Issue
libs/WPMKTENGINE/Wordpress/MetaboxCTA.php - Fixed incorrect sanitization logic in save() method that was corrupting nested array data, causing dynamic CTA selections (sidebar, position) to not persist on post save

Testing
All modified files pass PHP syntax validation
Fixes address warnings reported on PHP 8.1/8.2 environments
Dynamic CTA functionality verified to properly save and persist selections

Backward Compatibility
All changes are backward compatible with earlier PHP versions. The fixes add defensive null checks and explicit property declarations that work across PHP 7.4+.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit properties, null-safety, and improved sanitization across key classes to eliminate PHP 8.1/8.2 warnings and reliably persist dynamic CTA selections.
> 
> - **Compatibility (PHP 8.1/8.2)**
>   - Add null-safety in `WPME/Customizer/TemplateStorage::__cleanUpForCustomizer()` and `removeSpecificStyleAttributes()`, and `WPMKTENGINE/Utils/Strings::toAscii()`.
>   - Guard `DOMDocument::saveHTML()` return value in `WPMKTENGINE/HtmlForm` when generating unique IDs and string output.
>   - Initialize/reset internal buffer in `WPME/Utils/FastImage` (`$str = ''`).
> - **Explicit property declarations (avoid dynamic properties)**
>   - `WPMKTENGINE/CTA`: add `public $id`.
>   - `WPMKTENGINE/Frontend`: add `var $hasMultipleCTAs`.
>   - `WPMKTENGINE/HtmlForm`: add typed `$msg` and refine types for form-related props.
>   - `WPMKTENGINE/Table`: add screen/pagination-related props (`$screenId`, `$screenOptions`, `$userPerpage`, `$perPage`, `$found_data`).
>   - `WPMKTENGINE/WidgetCTAVisible`: add `$ctas`, `$selected`.
>   - `WPMKTENGINE/Wordpress/TableLite`: add protected `$_column_headers` cache.
> - **Metabox robustness**
>   - `Wordpress/Metabox`: skip fields missing required keys; safer render/save handling.
>   - `Wordpress/MetaboxCTA`: sanitize nested array inputs and preserve structure to correctly save `cta`/`sidebar`/`position` selections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b35bba370757b78b8c45d50067ffe6020ed6f4ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->